### PR TITLE
[ENHANCEMENT] Raise TooManyRequests exception when status 429

### DIFF
--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -183,4 +183,5 @@ module Quickbooks
     end
   end
 
+  class TooManyRequests < StandardError; end
 end

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -251,6 +251,8 @@ module Quickbooks
           raise Quickbooks::AuthorizationFailure
         when 403
           raise Quickbooks::Forbidden
+        when 429
+          raise Quickbooks::TooManyRequests
         when 400, 500
           parse_and_raise_exception(options)
         when 503, 504


### PR DESCRIPTION
When Quickbooks respond with status 429, raise a `Quickbooks::TooManyRequests` exception.